### PR TITLE
Updated css classes of content div for wide screens

### DIFF
--- a/authentic-lib.pl
+++ b/authentic-lib.pl
@@ -2237,7 +2237,7 @@ sub content
     print '<div id="content" class="__page' .
       ($theme_config{'settings_right_page_hide_persistent_vscroll'} eq 'false' ? ' fvscroll' : undef) . '">' . "\n";
 
-    print ' <div class="container-fluid col-lg-10 col-lg-offset-1" data-dcontainer="1"></div>' . "\n";
+    print ' <div class="container-fluid col-md-12" data-dcontainer="1"></div>' . "\n";
 }
 
 sub update_notice


### PR DESCRIPTION
Remove unnecessary side-margins from the main content div that is visible in wide screens (1920px+) by:

- Removing offset from the content panel column.
- Setting columns to 12 instead of 10.

BEFORE above changes in 1920px+ screens: https://raw.githubusercontent.com/andrewl64/authentic-theme/master/vmin-before.png
AFTER above changes in 1920px+ screens: https://raw.githubusercontent.com/andrewl64/authentic-theme/master/vmin-after.png