### PR TITLE
Add ability to collect stats via WebSocket

### DIFF
--- a/lang/en
+++ b/lang/en
@@ -1465,3 +1465,5 @@ theme_xhred_global_watching=Watching
 theme_xhred_global_connected=Connected
 theme_xhred_global_disconnected=Disconnected
 theme_xhred_global_connecting=Connecting
+index_mods_missing=The Perl module <tt>$1</tt> is missing.
+index_noadmin_eaccess=Access denied to non-master administrators!

--- a/stats-socket.cgi
+++ b/stats-socket.cgi
@@ -22,8 +22,8 @@ my @modnames = ("Digest::SHA", "Digest::MD5", "IO::Select",
                 "Time::HiRes", "Net::WebSocket::Server");
 
 foreach my $modname (@modnames) {
-	eval "use ${modname};";
-	if ($@) {
+    eval "use ${modname};";
+    if ($@) {
         push(@errors, $@, $modname);
         push(@errors, text('index_mods_missing', $modname));
         last;

--- a/stats-socket.cgi
+++ b/stats-socket.cgi
@@ -1,0 +1,54 @@
+#
+# Authentic Theme (https://github.com/authentic-theme/authentic-theme)
+# Copyright Ilia Rostovtsev <ilia@virtualmin.com>
+# Licensed under MIT (https://github.com/authentic-theme/authentic-theme/blob/master/LICENSE)
+#
+use strict;
+
+require($ENV{'THEME_ROOT'} . "/stats-lib.pl");
+our ($config_directory, $current_theme, $root_directory, $var_directory, %text);
+do "$root_directory/websockets-lib-funcs.pl";
+
+# Check access
+init_prefail();
+if (!defined(&webmin_user_is_admin) || !webmin_user_is_admin()) {
+    print_json({ error => $text{'index_noadmin_eaccess'}, access => 0 });
+    exit;
+}
+
+# Check dependencies
+my @errors;
+my @modnames = ("Digest::SHA", "Digest::MD5", "IO::Select",
+                "Time::HiRes", "Net::WebSocket::Server");
+
+foreach my $modname (@modnames) {
+	eval "use ${modname};";
+	if ($@) {
+        push(@errors, $@, $modname);
+        push(@errors, text('index_mods_missing', $modname));
+        last;
+    }
+}
+if (@errors) {
+    print_json({ error => $errors[2], 
+                 error_module => $errors[1],
+                 error_stack => $errors[0] });
+    exit;
+}
+
+# Allocate port
+my $port = &allocate_miniserv_websocket();
+
+# Launch the stats server
+my $server_name = "stats.pl";
+my $statsserver_cmd = "$config_directory/$current_theme/$server_name";
+&create_wrapper($statsserver_cmd, $current_theme, $server_name)
+    if (!-r $statsserver_cmd);
+
+# Launch the server
+my $logfile = "$var_directory/modules/$current_theme/stats-server-$port.log";
+my $rs = &system_logged(
+    "SESSION_ID=$main::session_id ".
+    "$statsserver_cmd @{[quotemeta($port)]} ".
+    ">$logfile 2>&1 </dev/null &");
+print_json({success => !$rs, port => $port, errlog => $logfile});

--- a/stats.pl
+++ b/stats.pl
@@ -1,0 +1,111 @@
+#!/usr/local/bin/perl
+
+#
+# Authentic Theme (https://github.com/authentic-theme/authentic-theme)
+# Copyright Ilia Rostovtsev <ilia@virtualmin.com>
+# Licensed under MIT (https://github.com/authentic-theme/authentic-theme/blob/master/LICENSE)
+#
+use lib ("$ENV{'PERLLIB'}/vendor_perl");
+use Net::WebSocket::Server;
+use utf8;
+use JSON;
+use threads;
+use threads::shared;
+use threads 'exit' => 'threads_only';
+
+require($ENV{'THEME_ROOT'} . "/stats-lib.pl");
+do "$root_directory/websockets-lib-funcs.pl";
+
+# Get port number
+my ($port) = @ARGV;
+
+# Check if user is admin
+if (!webmin_user_is_admin()) {
+    &remove_miniserv_websocket($port);
+    &error_stderr("Access denied to non-master administrators!");
+    exit(2);
+}
+
+# Clean up when socket is terminated
+$SIG{'ALRM'} = sub {
+	&remove_miniserv_websocket($port);
+	&error_stderr("Timeout waiting for connection");
+	exit(1);
+	};
+alarm(60);
+
+# Log successful connection
+&error_stderr("Listening on port $port");
+
+# Used variables
+my ($wsconn, $thread);
+my $stats_extract :shared = 0;
+my $stats_interval :shared = 1;
+my $stats_running :shared = 0;
+
+# Start WebSocket server
+Net::WebSocket::Server->new(
+	listen     => $port,
+	on_connect => sub {
+		my ($serv, $conn) = @_;
+		&error_stderr("WebSocket connection established");
+		if ($wsconn) {
+			&error_stderr("Unexpected another connection attempted to the same port.");
+			$wsconn->disconnect();
+			return;
+        }
+		$wsconn = $conn;
+		alarm(0);
+		
+        $conn->on(
+			handshake => sub {
+				# Is the key valid for this Webmin session?
+				my ($conn, $handshake) = @_;
+				my $key   = $handshake->req->fields->{'sec-websocket-key'};
+				my $dsess = &encode_base64($main::session_id);
+				$key   =~ s/\s//g;
+				$dsess =~ s/\s//g;
+				if (!$key || !$dsess || $key ne $dsess) {
+					&error_stderr("Key $key does not match session ID $dsess");
+					$conn->disconnect();
+					}
+				},
+			utf8 => sub {
+				my ($conn, $msg) = @_;
+				utf8::encode($msg) if (utf8::is_utf8($msg));
+				my $data = decode_json($msg);
+                $stats_extract = $data->{'save'};
+                $stats_interval = $data->{'interval'};
+                $stats_running = $data->{'running'};
+                my $collect = sub {
+                    while ($stats_running) {
+                        $wsconn->send_utf8(encode_json(stats($stats_extract)));
+                        sleep($stats_interval);
+                    }
+                };
+
+                # Ensure thread is restarted if needed
+                if (!$stats_running) {
+                    $thread->join() if ($thread && $thread->is_joinable());
+                    $thread = undef;
+                }
+                # Initiate non-blocking data collection using shared
+                # variables for controlling the loop from the client
+                if ($stats_running && (!$thread || !$thread->is_running())) {
+                    $thread = threads->create($collect);
+                }
+			},
+			disconnect => sub {
+				&error_stderr("WebSocket connection closed");
+				&remove_miniserv_websocket($port);
+				kill('KILL', $pid) if ($pid);
+				exit(0);
+				}
+			);
+	},
+)->start;
+&error_stderr("Exited WebSocket server");
+&remove_miniserv_websocket($port);
+&cleanup_miniserv_websockets([$port]);
+
+# 1;


### PR DESCRIPTION
Howdy y'all,

I have added the ability to collect stats using WebSocket. It's twice as fast and avoids server bombardment every second. The process can be fully controlled: collection can be enabled or disabled, the collection interval can be changed, all without disconnecting.

1. Open WebSocket by running:

```
https://localhost:10000/stats-socket.cgi
```

2. Connect using browser:

```JS
let socket = new WebSocket("wss://localhost:10000/authentic-theme/ws-555");

socket.onopen = function() {
    console.log("Connected to server");
    // Send initial parameters to the server
    socket.send(JSON.stringify({ save: 0, interval: 2, running: 1 }));
};

socket.onmessage = function(event) {
    let message = JSON.parse(event.data);
    console.log("Received stats:", message);
};

socket.onclose = function() {
    console.log("Disconnected from server");
};
```

3. Try controlling connection:

```JS
socket.send(JSON.stringify({ save: 0, interval: 0, running: 1 })); // higher the interval
socket.send(JSON.stringify({ save: 0, interval: 0, running: 0 })); // pause collection
socket.close(); // disconnect
```