### PR TITLE
Fix module page restore after full page reload (Ctrl+F5)

### DIFF
--- a/authentic-init.pl
+++ b/authentic-init.pl
@@ -939,7 +939,15 @@ sub init_vars
     our $title   = &get_html_framed_title();
     our %cookies = get_cookies();
 
-    my $server_x_goto_ = get_theme_temp_data('goto');
+    # Only consume the one-shot goto page on a real page request (REQUEST_URI
+    # present). A background/non-CGI request with an empty REQUEST_URI could
+    # otherwise read and delete the goto file before the actual "/" request
+    # that follows an ?xnavigation=1 redirect, breaking page restore after a
+    # full page reload (e.g. Ctrl+F5).
+    my $server_x_goto_;
+    if ($ENV{'REQUEST_URI'}) {
+        $server_x_goto_ = get_theme_temp_data('goto');
+    }
     if ($server_x_goto_) {
         $server_x_goto = $server_x_goto_;
         setvar('theme-goto', $server_x_goto);


### PR DESCRIPTION
# Fix module page restore after full page reload (Ctrl+F5)

Fixes: #1736

## Problem

After a full page reload (Ctrl+F5), authentic-theme sometimes fails to restore
the module page and lands on the dashboard instead.

## Root cause

The one-shot "goto" file (written on `?xnavigation=1` redirects to `/`) is
read and deleted by `init_vars()` via `get_theme_temp_data('goto')`. A
background/non-CGI request with an **empty `REQUEST_URI`** can consume this
file before the real `/` request runs `init_vars()`, so `nav_detector()` finds
no goto target and falls back to `/sysinfo.cgi`.

This is a server-side race; it is distinct from (and complementary to) the
existing `pragma_no_cache` logic, which only addresses the browser-side
heuristic cache of the root page.

## Fix

Only consume the goto file on a real page request (when `REQUEST_URI` is
present). Background requests with an empty `REQUEST_URI` leave the file
untouched, so the actual `/` request still finds it.

## Testing

Reproduced on Webmin 2.660 / authentic-theme 26.60 with a custom module:

- Before: Ctrl+F5 on `/mod/` lands on `/sysinfo.cgi` (goto consumed by an
  empty-`REQUEST_URI` background request).
- After: Ctrl+F5 on `/mod/` restores `/mod/`.

Verified that official modules (e.g. `/sshd/`) continue to restore correctly.
